### PR TITLE
Add UV2 generation

### DIFF
--- a/addons/godotvmf/utils/MDLManager.gd
+++ b/addons/godotvmf/utils/MDLManager.gd
@@ -93,8 +93,22 @@ static func loadModel(modelPath: String, generateCollision: bool = false, genera
 
 	if ResourceLoader.exists(resourcePath):
 		var res = load(resourcePath);
-		MDLManager.cache[h] = res;
-		return res;
+		
+		if generateLightmapUV2:
+			## Issue: PackedScene metadata is not saved #76366
+			## We're doing it to store texel size and rebuild tscn on texel size change
+			var file = FileAccess.open(resourcePath.replace('.tscn', '.tscn_meta'), FileAccess.READ)
+
+			if file:
+				var meta = JSON.parse_string(file.get_line())
+				
+				if meta and 'lightmapTexelSize' in meta and meta['lightmapTexelSize'] == lightmapTexelSize:
+					MDLManager.cache[h] = res;
+					return res;
+		else:
+			MDLManager.cache[h] = res;
+			return res;
+
 
 	var materials = getModelMaterials(modelPath)\
 	.map(
@@ -119,6 +133,13 @@ static func loadModel(modelPath: String, generateCollision: bool = false, genera
 	
 	if generateLightmapUV2:
 		mesh.lightmap_unwrap(model.global_transform, lightmapTexelSize);
+		## Issue: PackedScene metadata is not saved #76366
+		## We're doing it to store texel size and rebuild tscn on texel size change
+		var tmp = { 'lightmapTexelSize': lightmapTexelSize }
+		var file = FileAccess.open(resourcePath.replace('.tscn', '.tscn_meta'), FileAccess.WRITE)
+
+		if file:
+			file.store_line(JSON.stringify(tmp))
 	
 	model.set_mesh(mesh);
 	root.add_child(model);

--- a/addons/godotvmf/utils/MDLManager.gd
+++ b/addons/godotvmf/utils/MDLManager.gd
@@ -70,7 +70,7 @@ static func getModelMaterials(modelPath: String):
 	return materials;
 
 
-static func loadModel(modelPath: String, generateCollision: bool = false):
+static func loadModel(modelPath: String, generateCollision: bool = false, generateLightmapUV2: bool = false, lightmapTexelSize: float = 0.4):
 	var input = (VMFConfig.config.gameInfoPath + '/' + modelPath).replace('//', '/');
 	var resourcePath = (VMFConfig.config.models.targetFolder + '/' + input.split('models/')[-1]).replace('.mdl', '.tscn');
 
@@ -116,6 +116,10 @@ static func loadModel(modelPath: String, generateCollision: bool = false):
 
 	root.name = modelPath.get_file().get_basename();
 	model.name = modelPath.get_file().get_basename() + '_mesh';
+	
+	if generateLightmapUV2:
+		mesh.lightmap_unwrap(model.global_transform, lightmapTexelSize);
+	
 	model.set_mesh(mesh);
 	root.add_child(model);
 	

--- a/addons/godotvmf/utils/VMFConfig.gd
+++ b/addons/godotvmf/utils/VMFConfig.gd
@@ -55,6 +55,7 @@ static func validateConfig():
 	checkKeys = [
 		"scale",
 		"generateCollision",
+		"lightmapTexelSize",
 		"entitiesFolder",
 		"instancesFolder",
 	];

--- a/addons/godotvmf/utils/VMFConfig.gd
+++ b/addons/godotvmf/utils/VMFConfig.gd
@@ -55,6 +55,7 @@ static func validateConfig():
 	checkKeys = [
 		"scale",
 		"generateCollision",
+		"generateLightmapUV2",
 		"lightmapTexelSize",
 		"entitiesFolder",
 		"instancesFolder",

--- a/addons/godotvmf/utils/VMFNode.gd
+++ b/addons/godotvmf/utils/VMFNode.gd
@@ -5,6 +5,11 @@ class_name VMFNode extends Node3D;
 @export_global_file("*.vmf")
 var vmf: String = '';
 
+@export()
+var generate_lightmap_uv2 : bool = false
+@export()
+var lightmap_texel_size : float = 0.4
+
 ## Full import of VMF with specified options
 @export var import: bool = false:
 	set(value):
@@ -30,6 +35,9 @@ func _importGeometry(_reimport = false):
 
 	if not mesh:
 		return;
+		
+	if generate_lightmap_uv2:
+		mesh.lightmap_unwrap(global_transform, lightmap_texel_size)
 
 	_currentMesh = MeshInstance3D.new();
 	_currentMesh.name = "Geometry";

--- a/addons/godotvmf/utils/VMFNode.gd
+++ b/addons/godotvmf/utils/VMFNode.gd
@@ -5,11 +5,6 @@ class_name VMFNode extends Node3D;
 @export_global_file("*.vmf")
 var vmf: String = '';
 
-@export()
-var generate_lightmap_uv2 : bool = false;
-@export()
-var lightmap_texel_size : float = 0.4;
-
 ## Full import of VMF with specified options
 @export var import: bool = false:
 	set(value):
@@ -36,8 +31,11 @@ func _importGeometry(_reimport = false):
 	if not mesh:
 		return;
 		
-	if generate_lightmap_uv2:
-		mesh.lightmap_unwrap(global_transform, lightmap_texel_size);
+	if VMFConfig.config.import.generateLightmapUV2:
+		mesh.lightmap_unwrap(
+			global_transform, 
+			VMFConfig.config.import.lightmapTexelSize
+			);
 
 	_currentMesh = MeshInstance3D.new();
 	_currentMesh.name = "Geometry";

--- a/addons/godotvmf/utils/VMFNode.gd
+++ b/addons/godotvmf/utils/VMFNode.gd
@@ -6,9 +6,9 @@ class_name VMFNode extends Node3D;
 var vmf: String = '';
 
 @export()
-var generate_lightmap_uv2 : bool = false
+var generate_lightmap_uv2 : bool = false;
 @export()
-var lightmap_texel_size : float = 0.4
+var lightmap_texel_size : float = 0.4;
 
 ## Full import of VMF with specified options
 @export var import: bool = false:
@@ -37,7 +37,7 @@ func _importGeometry(_reimport = false):
 		return;
 		
 	if generate_lightmap_uv2:
-		mesh.lightmap_unwrap(global_transform, lightmap_texel_size)
+		mesh.lightmap_unwrap(global_transform, lightmap_texel_size);
 
 	_currentMesh = MeshInstance3D.new();
 	_currentMesh.name = "Geometry";

--- a/addons/godotvmf/utils/VMFNode.gd
+++ b/addons/godotvmf/utils/VMFNode.gd
@@ -121,7 +121,13 @@ func _importModels():
 		if not "model" in ent:
 			continue;
 
-		var resource = MDLManager.loadModel(ent.model, VMFConfig.config.models.generateCollision);
+		var lightmapTexelSize = VMFConfig.config.models.lightmapTexelSize
+
+		if VMFConfig.config.import.generateLightmapUV2 and "lightmapTexelSize" in ent:
+			lightmapTexelSize = float(ent.lightmapTexelSize)
+			VMFLogger.log('prop_static (%s) overrides lightmapTexelSize to \'%f\'' % [ent.id, lightmapTexelSize])
+
+		var resource = MDLManager.loadModel(ent.model, VMFConfig.config.models.generateCollision, VMFConfig.config.import.generateLightmapUV2, lightmapTexelSize);
 		var importScale = VMFConfig.config.import.scale;
 
 		if not resource:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,7 +57,7 @@ The blank mod folder you can download here: [Google Drive](https://drive.google.
 - `models (optional)`
     - `import` - If `true` then importer will try to import models from the mod's folder.
     - `generateCollision` - If `true` then generates `CollisionShape3D` for imported geometry.
-    - `lightmapTexelSize` - If `true` then generates UV2 for static props for light baking (global default value, can be overridden by `lightmapTexelSize` keyvalue in `prop_static` entity, which can be manually added using `Add` button in object properties).
+    - `lightmapTexelSize` - If `true` then generates UV2 for static props for light baking (global default value, can be overridden by eponymous keyvalue in `prop_static` entity, which can be manually added using `Add` button in object properties).
     - `targetFolder` - Path inside the project where imported models be placed.
 - `material`
     - `importMode` - The mode of importing materials

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,6 +22,7 @@ Default config:
 	"models": {
 		"import": true,
 		"generateCollision": true,
+		"lightmapTexelSize": 0.4,
 		"targetFolder": "res://examples/models"
 	},
 
@@ -49,13 +50,14 @@ The blank mod folder you can download here: [Google Drive](https://drive.google.
 - `import'
     - `scale` - In case you need to convert Valve's metrics to yours.
     - `generateCollision` - If `true` then generates `CollisionShape3D` for imported geometry (except brush entities) by using trimesh shape.
-	- `generateLightmapUV2` - If `true` then generates UV2 for light baking.
+	- `generateLightmapUV2` - If `true` then generates UV2 to enable light baking.
 	- `lightmapTexelSize` - Size of each texel in the lightmap for more precise light baking (use with caution, very low values can cause crash).
     - `instancesFolder` - Path inside the project where imported instances be placed.
     - `entitiesFolder` - Path inside the project where importer will grab entities during import.
 - `models (optional)`
     - `import` - If `true` then importer will try to import models from the mod's folder.
     - `generateCollision` - If `true` then generates `CollisionShape3D` for imported geometry.
+    - `lightmapTexelSize` - If `true` then generates UV2 for static props for light baking (global default value, can be overridden by `lightmapTexelSize` keyvalue in `prop_static` entity, which can be manually added using `Add` button in object properties).
     - `targetFolder` - Path inside the project where imported models be placed.
 - `material`
     - `importMode` - The mode of importing materials

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,6 +13,8 @@ Default config:
 	"import": {
 		"scale": 0.025,
 		"generateCollision": true,
+		"generateLightmapUV2": true,
+		"lightmapTexelSize": 0.4,
 		"instancesFolder": "res://examples/instances",
 		"entitiesFolder": "res://examples/entities"
 	},
@@ -47,6 +49,8 @@ The blank mod folder you can download here: [Google Drive](https://drive.google.
 - `import'
     - `scale` - In case you need to convert Valve's metrics to yours.
     - `generateCollision` - If `true` then generates `CollisionShape3D` for imported geometry (except brush entities) by using trimesh shape.
+	- `generateLightmapUV2` - If `true` then generates UV2 for light baking.
+	- `lightmapTexelSize` - Size of each texel in the lightmap for more precise light baking (use with caution, very low values can cause crash).
     - `instancesFolder` - Path inside the project where imported instances be placed.
     - `entitiesFolder` - Path inside the project where importer will grab entities during import.
 - `models (optional)`

--- a/vmf.config.json
+++ b/vmf.config.json
@@ -14,6 +14,7 @@
 	"models": {
 		"import": true,
 		"generateCollision": true,
+		"lightmapTexelSize": 0.4,
 		"targetFolder": "res://examples/models"
 	},
 

--- a/vmf.config.json
+++ b/vmf.config.json
@@ -5,6 +5,8 @@
 	"import": {
 		"scale": 0.025,
 		"generateCollision": true,
+		"generateLightmapUV2": true,
+		"lightmapTexelSize": 0.4,
 		"instancesFolder": "res://examples/instances",
 		"entitiesFolder": "res://examples/entities"
 	},


### PR DESCRIPTION
Greetings, H2xDev.

Recently, I found this project while searching for a more convenient way to create geometry for levels, and I really liked it, since I used to Source/2. However, manual creation of UV2 maps each time is not good. 
As it turns out, by adding a few lines of code, the ability to automatically generate UV2 maps becomes available.

![image](https://github.com/H2xDev/GodotVMF/assets/41019056/bd2e97ed-e3a4-4e9a-8e37-99313bb912d2)

# New properties in VMFNode

![image](https://github.com/H2xDev/GodotVMF/assets/41019056/e0d96ea1-34b6-42b2-bdb0-a7c6b2eca8f7)
