### PR TITLE
Inherit instantiated scenes properly to save disk space

### DIFF
--- a/addons/godotvmf/entities/func_instance.gd
+++ b/addons/godotvmf/entities/func_instance.gd
@@ -15,7 +15,7 @@ func assign_instance(instance_scene):
 		queue_free();
 		return;
 
-	var node = instance_scene.instantiate() as VMFNode;
+	var node = instance_scene.instantiate(PackedScene.GEN_EDIT_STATE_MAIN_INHERITED) as VMFNode;
 
 	var i = 1
 	for child: Node in get_parent().get_children():

--- a/addons/godotvmf/entities/prop_studio.gd
+++ b/addons/godotvmf/entities/prop_studio.gd
@@ -22,7 +22,7 @@ func _apply_entity(e: Dictionary) -> void:
 		VMFLogger.error("Failed to load model scene: " + model_path);
 		return;
 
-	var instance := model_scene.instantiate();
+	var instance := model_scene.instantiate(PackedScene.GEN_EDIT_STATE_MAIN_INHERITED);
 	instance.name = "model";
 
 	add_child(instance);

--- a/addons/godotvmf/src/VMFNode.gd
+++ b/addons/godotvmf/src/VMFNode.gd
@@ -389,7 +389,7 @@ func import_entities(is_reimport := false) -> void:
 		var tscn = get_entity_scene(ent.classname);
 		if not tscn: continue;
 
-		var node = tscn.instantiate();
+		var node = tscn.instantiate(PackedScene.GEN_EDIT_STATE_MAIN_INHERITED);
 		if "is_runtime" in node:
 			node.is_runtime = is_runtime;
 


### PR DESCRIPTION
See [Discord conversation](https://discord.com/channels/1209893259674132551/1210326370551464006/1412035855606087750).

This PR uses **PackedScene.GEN_EDIT_STATE_MAIN_INHERITED** for every PackedScene instantiation in GodotVMF. Without it, as was previously the case, the scenes instantiated **in the editor** were essentially duplicates of the originals.

Doing this saves **so** much disk space and memory overall and should be a net positive for everyone using this addon.