### PR TITLE
Do not use text resources for import save extensions

### DIFF
--- a/addons/godotvmf/godotmdl/import.gd
+++ b/addons/godotvmf/godotmdl/import.gd
@@ -4,7 +4,7 @@ class_name MDLImporter extends EditorImportPlugin
 func _get_importer_name(): return "MDL"
 func _get_visible_name(): return "MDL"
 func _get_recognized_extensions(): return ["mdl"];
-func _get_save_extension(): return "tscn";
+func _get_save_extension(): return "scn";
 func _get_resource_type(): return "PackedScene";
 func _get_priority(): return 1;
 func _get_preset_count(): return 0;

--- a/addons/godotvmf/godotvmt/vmt_import.gd
+++ b/addons/godotvmf/godotvmt/vmt_import.gd
@@ -4,7 +4,7 @@ class_name VMTImporter extends EditorImportPlugin
 func _get_importer_name(): return "VMT";
 func _get_visible_name(): return "VMT Importer";
 func _get_recognized_extensions(): return ["vmt"];
-func _get_save_extension(): return "vmt.tres";
+func _get_save_extension(): return "vmt.res";
 func _get_resource_type(): return "Material";
 func _get_preset_count(): return 0;
 func _get_import_order(): return 1;

--- a/addons/godotvmf/godotvmt/vtf_import.gd
+++ b/addons/godotvmf/godotvmt/vtf_import.gd
@@ -4,7 +4,7 @@ class_name VTFImporter extends EditorImportPlugin
 func _get_importer_name(): return "VTF";
 func _get_visible_name(): return "VTF Importer";
 func _get_recognized_extensions(): return ["vtf"];
-func _get_save_extension(): return "vtf.tres";
+func _get_save_extension(): return "vtf.res";
 func _get_resource_type(): return "Texture";
 func _get_preset_count(): return 0;
 func _get_import_order(): return 0;


### PR DESCRIPTION
GodotVMF imports models, textures, and materials with the `.tscn` and `.tres` extension. The `t` stands for "Text". This means that these resources are imported and stored in full text format, which can be easy to parse but it's *exceedingly* inefficient, even in **exported** release builds.

This can easily be addressed by using the binary `.scn` and `.res` extensions instead, which are much, much smaller in comparison.

Note that, the binary extensions are how Godot imports most resources. It's possible to verify how resources are imported by checking the `.godot/imported` folder. You may also manually save a scene or resource in your project as binary and the engine will convert between the formats seamlessly.

