### PR TITLE
Fix VMFConfig not loaded on project startup

### DIFF
--- a/addons/godotvmf/godotvmf.gd
+++ b/addons/godotvmf/godotvmf.gd
@@ -38,8 +38,9 @@ func _enter_tree() -> void:
 	entity_context_plugin = VMFEntityContextMenu.new();
 	add_context_menu_plugin(EditorContextMenuPlugin.CONTEXT_SLOT_FILESYSTEM, entity_context_plugin);
 
+	VMFConfig.load_config()
+
 func _exit_tree():
-	remove_autoload_singleton("VMFConfig");
 	remove_custom_type("VMFNode");
 	remove_custom_type("ValveIONode");
 	


### PR DESCRIPTION
This PR ensures that the **VMFConfig** class is at least up-to-date when the addon is loaded.
Without this, there are many occasions where the config file is not respected (such as during model and material import), causing the VMFConfig class to be stuck on its default values (particularly noticeable for file paths), until some other function calls `load_config`.

Do note that this is still not ideal.
Please keep in mind of the existing issue: if the config file is changed during execution, it's not guaranteed that **VMFConfig** class will change accordingly. *Ideally*, this should be handled by reloading the config for every operation that needs it, but that's exceedingly inefficient and "stupid".

Also removes a leftover line attempting to remove the **VMFConfig** autoload that is no longer an autoload.