### PR TITLE
Add wildcard support for targetnames

### DIFF
--- a/addons/godotvmf/src/ValveIONode.gd
+++ b/addons/godotvmf/src/ValveIONode.gd
@@ -140,6 +140,17 @@ static func get_target(n, caller = null) -> Node3D:
 
 ## Returns all nodes with the targetname
 static func get_all_targets(target_name: String, caller = null) -> Array:
+
+	if target_name.ends_with("*"):
+		var entities: Array[ValveIONode] = []
+		for key: String in ValveIONode.named_entities.keys():
+			
+			if key.begins_with(target_name.left(-1)):
+				for named_entity: ValveIONode in ValveIONode.named_entities[key]:
+					entities.push_back(named_entity)
+				
+		return entities
+
 	if scene_instance.get_tree().has_group(target_name):
 		return scene_instance.get_tree().get_nodes_in_group(target_name);
 


### PR DESCRIPTION
The Source Engine allows for wildcards (*) at the end of entity names for I/O (see https://developer.valvesoftware.com/wiki/Targetname) which will match any entity containing the characters preceding the asterisk character. This can be useful when needing to run inputs on multiple entities with similar names.

This PR introduces support for trailing wildcards by modifying the get_all_targets() function in ValveIONode.gd