### PR TITLE
Import: Add multiple game import paths support

### DIFF
--- a/addons/godotvmf/src/vmf_config.gd
+++ b/addons/godotvmf/src/vmf_config.gd
@@ -3,28 +3,129 @@ class_name VMFConfig extends RefCounted
 
 const CONFIG_FILE_PATH = "res://vmf.config.json";
 
-const SETTINGS_TO_LOAD = [
-	"godot_vmf/models/import",
-	"godot_vmf/models/target_folder",
-	"godot_vmf/models/lightmap_texel_size",
-	"godot_vmf/materials/import_mode",
-	"godot_vmf/materials/target_folder",
-	"godot_vmf/materials/ignore",
-	"godot_vmf/materials/fallback_material",
-	"godot_vmf/materials/default_texture_size",
-	"godot_vmf/import/scale",
-	"godot_vmf/import/generate_lightmap_uv2",
-	"godot_vmf/import/generate_collision",
-	"godot_vmf/import/generate_navigation_mesh",
-	"godot_vmf/import/navigation_mesh_preset",
-	"godot_vmf/import/lightmap_texel_size",
-	"godot_vmf/import/instances_folder",
-	"godot_vmf/import/entities_folder",
-	"godot_vmf/import/geometry_folder",
-	"godot_vmf/import/entity_aliases",
-	"godot_vmf/import/detail_props_chunk_size",
-	"godot_vmf/import/detail_props_draw_distance",
-];
+const SETTINGS_TO_LOAD = {
+	"godot_vmf/import/gameinfo_path": {
+		"default_value": "res://",
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_GLOBAL_DIR,
+	},
+	"godot_vmf/models/import": {
+		"default_value": false,
+		"type": TYPE_BOOL,
+		"hint": PROPERTY_HINT_NONE,
+	},
+	"godot_vmf/models/target_folder": {
+		"default_value": "res://",
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_NONE,
+	},
+	"godot_vmf/models/lightmap_texel_size": {
+		"default_value": 0.4,
+		"type": TYPE_FLOAT,
+		"hint": PROPERTY_HINT_RANGE,
+		"hint_string": "0,100.0,0.000001",
+	},
+	"godot_vmf/materials/import_mode": {
+		"default_value": 0,
+		"type": TYPE_INT,
+		"hint": PROPERTY_HINT_ENUM,
+		"hint_string": "Use Existing, Import from the GameInfo folder",
+	},
+	"godot_vmf/materials/target_folder": {
+		"default_value": "res://materials",
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_NONE,
+	},
+	"godot_vmf/materials/ignore": {
+		"default_value": ["tools/toolsnodraw", "tools/toolsskybox", "tools/toolsinvisible"],
+		"type": TYPE_ARRAY,
+		"hint": PROPERTY_HINT_ARRAY_TYPE,
+		"hint_string": "%d:String" % TYPE_STRING,
+	},
+	"godot_vmf/materials/fallback_material": {
+		"default_value": "",
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_RESOURCE_TYPE,
+		"hint_string": "Material",
+	},
+	"godot_vmf/materials/default_texture_size": {
+		"default_value": 512,
+		"type": TYPE_INT,
+		"hint": PROPERTY_HINT_NONE,
+	},
+	"godot_vmf/import/scale": {
+		"default_value": 0.02,
+		"type": TYPE_FLOAT,
+		"hint": PROPERTY_HINT_RANGE,
+		"hint_string": "0,100.0,0.000001",
+	},
+	"godot_vmf/import/generate_lightmap_uv2": {
+		"default_value": true,
+		"type": TYPE_BOOL,
+		"hint": PROPERTY_HINT_NONE,
+	},
+	"godot_vmf/import/generate_collision": {
+		"default_value": true,
+		"type": TYPE_BOOL,
+		"hint": PROPERTY_HINT_NONE,
+	},
+	"godot_vmf/import/generate_navigation_mesh": {
+		"default_value": false,
+		"type": TYPE_BOOL,
+		"hint": PROPERTY_HINT_NONE,
+	},
+	"godot_vmf/import/navigation_mesh_preset": {
+		"default_value": "",
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_RESOURCE_TYPE,
+		"hint_string": "NavigationMesh",
+	},
+	"godot_vmf/import/lightmap_texel_size": {
+		"default_value": 0.2,
+		"type": TYPE_FLOAT,
+		"hint": PROPERTY_HINT_RANGE,
+		"hint_string": "0,100.0,0.000001",
+	},
+	"godot_vmf/import/instances_folder": {
+		"default_value": "res://instances",
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_DIR,
+	},
+	"godot_vmf/import/entities_folder": {
+		"default_value": "res://entities",
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_DIR,
+	},
+	"godot_vmf/import/geometry_folder": {
+		"default_value": "res://geometry",
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_DIR,
+	},
+	"godot_vmf/import/entity_aliases": {
+		"default_value": {},
+		"type": TYPE_DICTIONARY,
+		"hint": PROPERTY_HINT_DICTIONARY_TYPE,
+		"hint_string": "%d:;%d/%d:*.tscn" % [TYPE_STRING, TYPE_STRING, PROPERTY_HINT_FILE],
+	},
+	"godot_vmf/import/detail_props_chunk_size": {
+		"default_value": 32.0,
+		"type": TYPE_FLOAT,
+		"hint": PROPERTY_HINT_RANGE,
+		"hint_string": "0,1000.0,0.000001",
+	},
+	"godot_vmf/import/detail_props_draw_distance": {
+		"default_value": 100.0,
+		"type": TYPE_FLOAT,
+		"hint": PROPERTY_HINT_RANGE,
+		"hint_string": "0,1000.0,0.000001",
+	},
+	"godot_vmf/import/additional_import_paths": {
+		"default_value": [],
+		"type": TYPE_ARRAY,
+		"hint": PROPERTY_HINT_ARRAY_TYPE,
+		"hint_string": "%d/%d:" % [TYPE_STRING, PROPERTY_HINT_GLOBAL_DIR],
+	}
+};
 
 class ModelsConfig:
 	## If true, the importer will import models from the mod folder
@@ -109,6 +210,8 @@ class ImportConfig:
 
 	var gameinfo_path: String = ProjectSettings.get_setting("godot_vmf/import/gameinfo_path", "res://");
 
+	var additional_import_paths: Array = ProjectSettings.get_setting("godot_vmf/import/additional_import_paths", []);
+
 ## NOTE: Support previous version of this config where this field wasn't a part of ImportConfig
 static var gameinfo_path: String:
 	get: return ProjectSettings.get_setting("godot_vmf/import/gameinfo_path", "res://");
@@ -164,275 +267,17 @@ static func detach_signals():
 	ProjectSettings.settings_changed.disconnect(update_config_field);
 
 static func define_project_settings():
-	if not ProjectSettings.has_setting("godot_vmf/import/gameinfo_path"):
-		ProjectSettings.set_setting("godot_vmf/import/gameinfo_path", "res://");
-	ProjectSettings.set_initial_value("godot_vmf/import/gameinfo_path", "res://");
-	ProjectSettings.set_as_basic("godot_vmf/import/gameinfo_path", true);
+	for setting in SETTINGS_TO_LOAD:
+		var info = SETTINGS_TO_LOAD[setting]
+		var default_val = info["default_value"]
+		if not ProjectSettings.has_setting(setting):
+			ProjectSettings.set_setting(setting, default_val)
+		ProjectSettings.set_initial_value(setting, default_val)
+		ProjectSettings.set_as_basic(setting, true)
 
-	## Import
-	if not ProjectSettings.has_setting("godot_vmf/import/scale"):
-		ProjectSettings.set_setting("godot_vmf/import/scale", 0.02);
-	ProjectSettings.set_initial_value("godot_vmf/import/scale", 0.02);
-	ProjectSettings.set_as_basic("godot_vmf/import/scale", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/import/generate_lightmap_uv2"):
-		ProjectSettings.set_setting("godot_vmf/import/generate_lightmap_uv2", true);
-	ProjectSettings.set_initial_value("godot_vmf/import/generate_lightmap_uv2", true);
-	ProjectSettings.set_as_basic("godot_vmf/import/generate_lightmap_uv2", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/import/generate_collision"):
-		ProjectSettings.set_setting("godot_vmf/import/generate_collision", true);
-	ProjectSettings.set_initial_value("godot_vmf/import/generate_collision", true);
-	ProjectSettings.set_as_basic("godot_vmf/import/generate_collision", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/import/generate_navigation_mesh"):
-		ProjectSettings.set_setting("godot_vmf/import/generate_navigation_mesh", false);
-	ProjectSettings.set_initial_value("godot_vmf/import/generate_navigation_mesh", false);
-	ProjectSettings.set_as_basic("godot_vmf/import/generate_navigation_mesh", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/import/navigation_mesh_preset"):
-		ProjectSettings.set_setting("godot_vmf/import/navigation_mesh_preset", "");
-	ProjectSettings.set_initial_value("godot_vmf/import/navigation_mesh_preset", "");
-	ProjectSettings.set_as_basic("godot_vmf/import/navigation_mesh_preset", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/import/lightmap_texel_size"):
-		ProjectSettings.set_setting("godot_vmf/import/lightmap_texel_size", 0.2);
-	ProjectSettings.set_initial_value("godot_vmf/import/lightmap_texel_size", 0.2);
-	ProjectSettings.set_as_basic("godot_vmf/import/lightmap_texel_size", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/import/instances_folder"):
-		ProjectSettings.set_setting("godot_vmf/import/instances_folder", "res://instances");
-	ProjectSettings.set_initial_value("godot_vmf/import/instances_folder", "res://instances");
-	ProjectSettings.set_as_basic("godot_vmf/import/instances_folder", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/import/entities_folder"):
-		ProjectSettings.set_setting("godot_vmf/import/entities_folder", "res://entities");
-	ProjectSettings.set_initial_value("godot_vmf/import/entities_folder", "res://entities");
-	ProjectSettings.set_as_basic("godot_vmf/import/entities_folder", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/import/geometry_folder"):
-		ProjectSettings.set_setting("godot_vmf/import/geometry_folder", "res://geometry");
-	ProjectSettings.set_initial_value("godot_vmf/import/geometry_folder", "res://geometry");
-	ProjectSettings.set_as_basic("godot_vmf/import/geometry_folder", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/import/entity_aliases"):
-		ProjectSettings.set_setting("godot_vmf/import/entity_aliases", {});
-	ProjectSettings.set_initial_value("godot_vmf/import/entity_aliases", {});
-	ProjectSettings.set_as_basic("godot_vmf/import/entity_aliases", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/import/detail_props_chunk_size"):
-		ProjectSettings.set_setting("godot_vmf/import/detail_props_chunk_size", 32.0);
-	ProjectSettings.set_initial_value("godot_vmf/import/detail_props_chunk_size", 32.0);
-	ProjectSettings.set_as_basic("godot_vmf/import/detail_props_chunk_size", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/import/detail_props_draw_distance"):
-		ProjectSettings.set_setting("godot_vmf/import/detail_props_draw_distance", 100.0);
-	ProjectSettings.set_initial_value("godot_vmf/import/detail_props_draw_distance", 100.0);
-	ProjectSettings.set_as_basic("godot_vmf/import/detail_props_draw_distance", true);
-	
-
-	## Models
-	if not ProjectSettings.has_setting("godot_vmf/models/import"):
-		ProjectSettings.set_setting("godot_vmf/models/import", false);
-	ProjectSettings.set_initial_value("godot_vmf/models/import", false);
-	ProjectSettings.set_as_basic("godot_vmf/models/import", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/models/target_folder"):
-		ProjectSettings.set_setting("godot_vmf/models/target_folder", "res://");
-	ProjectSettings.set_initial_value("godot_vmf/models/target_folder", "res://");
-	ProjectSettings.set_as_basic("godot_vmf/models/target_folder", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/models/lightmap_texel_size"):
-		ProjectSettings.set_setting("godot_vmf/models/lightmap_texel_size", 0.4);
-	ProjectSettings.set_initial_value("godot_vmf/models/lightmap_texel_size", 0.4);
-	ProjectSettings.set_as_basic("godot_vmf/models/lightmap_texel_size", true);
-
-	## Materials
-	if not ProjectSettings.has_setting("godot_vmf/materials/import_mode"):
-		ProjectSettings.set_setting("godot_vmf/materials/import_mode", 0);
-	ProjectSettings.set_initial_value("godot_vmf/materials/import_mode", 0);
-	ProjectSettings.set_as_basic("godot_vmf/materials/import_mode", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/materials/target_folder"):
-		ProjectSettings.set_setting("godot_vmf/materials/target_folder", "res://materials");
-	ProjectSettings.set_initial_value("godot_vmf/materials/target_folder", "res://materials");
-	ProjectSettings.set_as_basic("godot_vmf/materials/target_folder", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/materials/ignore"):
-		ProjectSettings.set_setting("godot_vmf/materials/ignore", ["tools/toolsnodraw", "tools/toolsskybox", "tools/toolsinvisible"]);
-	ProjectSettings.set_initial_value("godot_vmf/materials/ignore", ["tools/toolsnodraw", "tools/toolsskybox", "tools/toolsinvisible"]);
-	ProjectSettings.set_as_basic("godot_vmf/materials/ignore", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/materials/fallback_material"):
-		ProjectSettings.set_setting("godot_vmf/materials/fallback_material", "");
-	ProjectSettings.set_initial_value("godot_vmf/materials/fallback_material", "");
-	ProjectSettings.set_as_basic("godot_vmf/materials/fallback_material", true);
-
-	if not ProjectSettings.has_setting("godot_vmf/materials/default_texture_size"):
-		ProjectSettings.set_setting("godot_vmf/materials/default_texture_size", 512);
-	ProjectSettings.set_initial_value("godot_vmf/materials/default_texture_size", 512);
-	ProjectSettings.set_as_basic("godot_vmf/materials/default_texture_size", true);
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/import/gameinfo_path",
-		"type": TYPE_STRING,
-		"hint": PROPERTY_HINT_GLOBAL_FILE ,
-		"hint_string": "gameinfo.txt,GameInfo.txt",
-		"default_value": 'res://',
-	})
-
-	## Import
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/import/scale",
-		"type": TYPE_FLOAT,
-		"hint": PROPERTY_HINT_RANGE,
-		"hint_string": "0,100.0,0.000001",
-		"default_value": 0.02,
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/import/generate_lightmap_uv2",
-		"type": TYPE_BOOL,
-		"hint": PROPERTY_HINT_NONE,
-		"default_value": true,
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/import/generate_navigation_mesh",
-		"type": TYPE_BOOL,
-		"hint": PROPERTY_HINT_NONE,
-		"default_value": false,
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/import/navigation_mesh_preset",
-		"type": TYPE_STRING,
-		"hint": PROPERTY_HINT_RESOURCE_TYPE,
-		"hint_string": "NavigationMesh",
-		"default_value": "",
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/import/generate_collision",
-		"type": TYPE_BOOL,
-		"hint": PROPERTY_HINT_NONE,
-		"default_value": false,
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/import/lightmap_texel_size",
-		"type": TYPE_FLOAT,
-		"hint": PROPERTY_HINT_RANGE,
-		"hint_string": "0,100.0,0.000001",
-		"default_value": 0.2,
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/import/instances_folder",
-		"type": TYPE_STRING,
-		"hint": PROPERTY_HINT_DIR,
-		"default_value": "res://instances",
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/import/entities_folder",
-		"type": TYPE_STRING,
-		"hint": PROPERTY_HINT_DIR,
-		"default_value": "res://entities",
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/import/geometry_folder",
-		"type": TYPE_STRING,
-		"hint": PROPERTY_HINT_DIR,
-		"default_value": "res://geometry",
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/import/entity_aliases",
-		"type": TYPE_DICTIONARY,
-		"hint": PROPERTY_HINT_DICTIONARY_TYPE,
-		"hint_string": "%d:;%d/%d:*.tscn" % [TYPE_STRING, TYPE_STRING, PROPERTY_HINT_FILE],
-		"default_value": {},
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/import/detail_props_chunk_size",
-		"type": TYPE_FLOAT,
-		"hint": PROPERTY_HINT_RANGE,
-		"hint_string": "0,1000.0,0.000001",
-		"default_value": 0.2,
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/import/detail_props_draw_distance",
-		"type": TYPE_FLOAT,
-		"hint": PROPERTY_HINT_RANGE,
-		"hint_string": "0,1000.0,0.000001",
-		"default_value": 0.2,
-	})
-
-	## Models
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/models/import",
-		"type": TYPE_BOOL,
-		"hint": PROPERTY_HINT_NONE,
-		"default_value": false
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/models/target_folder",
-		"type": TYPE_STRING,
-		"hint": PROPERTY_HINT_NONE,
-		"default_value": "res://"
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/models/lightmap_texel_size",
-		"type": TYPE_FLOAT,
-		"hint": PROPERTY_HINT_RANGE,
-		"hint_string": "0,100.0,0.000001",
-		"default_value": 0.4,
-	})
-
-	## Materials
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/materials/import_mode",
-		"type": TYPE_INT,
-		"hint": PROPERTY_HINT_ENUM,
-		"hint_string": "Use Existing, Import from the GameInfo folder",
-		"default_value": 0,
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/materials/target_folder",
-		"type": TYPE_STRING,
-		"hint": PROPERTY_HINT_NONE,
-		"default_value": "res://materials",
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/materials/ignore",
-		"type": TYPE_ARRAY,
-		"hint": PROPERTY_HINT_ARRAY_TYPE,
-		"hint_string": "%d:String" % TYPE_STRING,
-		"default_value": ["tools/toolsnodraw", "tools/toolsskybox", "tools/toolsinvisible"],
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/materials/fallback_material",
-		"type": TYPE_STRING,
-		"hint": PROPERTY_HINT_RESOURCE_TYPE,
-		"hint_string": "Material",
-		"default_value": "",
-	})
-
-	ProjectSettings.add_property_info({
-		"name": "godot_vmf/materials/default_texture_size",
-		"type": TYPE_INT,
-		"hint": PROPERTY_HINT_NONE,
-		"default_value": 512,
-	})
+		var prop_info = info.duplicate()
+		prop_info["name"] = setting
+		ProjectSettings.add_property_info(prop_info)
 
 	ProjectSettings.settings_changed.connect.call_deferred(update_config_field);
 

--- a/addons/godotvmf/src/vmf_game_folder.gd
+++ b/addons/godotvmf/src/vmf_game_folder.gd
@@ -1,0 +1,21 @@
+@static_unload
+class_name VMFGameFolder extends RefCounted
+
+## Returns an array of all game folder paths, including the main gameinfo path and any additional import paths
+static func get_all_paths() -> Array[String]:
+	var paths: Array[String] = [VMFConfig.gameinfo_path];
+	paths += VMFConfig.import.additional_import_paths;
+
+	return paths;
+
+## Returns the full path to the file if it exists in any of the game folder paths, otherwise returns an empty string
+static func get_import_path(file_path: String) -> String:
+	for path in get_all_paths():
+		var full_path = VMFUtils.normalize_path(path + "/" + file_path);
+		if FileAccess.file_exists(full_path):
+			return full_path;
+
+	return "";
+
+static func file_exists(file_path: String) -> bool:
+	return get_import_path(file_path) != "";

--- a/addons/godotvmf/src/vmf_game_folder.gd.uid
+++ b/addons/godotvmf/src/vmf_game_folder.gd.uid
@@ -1,0 +1,1 @@
+uid://bygdwe5ixcppv

--- a/addons/godotvmf/src/vmf_resource_manager.gd
+++ b/addons/godotvmf/src/vmf_resource_manager.gd
@@ -22,6 +22,9 @@ static func init_vpk_stack() -> void:
 	if not VMFConfig.models.import and VMFConfig.materials.import_mode == VMFConfig.MaterialsConfig.ImportMode.USE_EXISTING: return;
 	vpk_stack = VPKStack.create(VMFConfig.gameinfo_path);
 
+	for path in VMFConfig.import.additional_import_paths:
+		vpk_stack.append(path);
+
 static func free_vpk_stack() -> void:
 	if vpk_stack:
 		vpk_stack.free_vpks();

--- a/addons/godotvmf/src/vmf_resource_manager.gd
+++ b/addons/godotvmf/src/vmf_resource_manager.gd
@@ -53,29 +53,30 @@ static func import_models(vmf_structure: VMFStructure) -> bool:
 		var model_path = entity.data.get("model", "").to_lower().get_basename();
 		if not model_path: continue;
 
-		# Game directory paths
-		var gamedir_path = VMFUtils.normalize_path(VMFConfig.gameinfo_path + "/" + model_path);
-		var mdl_path = VMFUtils.normalize_path(gamedir_path + ".mdl");
-		var vtx_path = VMFUtils.normalize_path(gamedir_path + ".vtx");
-		var vtx_dx90_path = VMFUtils.normalize_path(gamedir_path + ".dx90.vtx");
-		var vvd_path = VMFUtils.normalize_path(gamedir_path + ".vvd");
-		var phy_path = VMFUtils.normalize_path(gamedir_path + ".phy");
-
 		# VPK paths
 		var vpk_mdl_path = VMFUtils.normalize_path(model_path + ".mdl");
 		var vpk_vtx_path = VMFUtils.normalize_path(model_path + ".dx90.vtx");
+		var vpk_vtx_fallback_path = VMFUtils.normalize_path(model_path + ".vtx");
 		var vpk_vvd_path = VMFUtils.normalize_path(model_path + ".vvd");
 		var vpk_phy_path = VMFUtils.normalize_path(model_path + ".phy");
 
 		var target_path = VMFUtils.normalize_path(VMFConfig.models.target_folder + "/" + model_path);
 
 		if ResourceLoader.exists(target_path + ".mdl"): continue;
-		
-		vtx_path = vtx_path if FileAccess.file_exists(vtx_path) and file_exists_in_vpk(vtx_path) else vtx_dx90_path
 
-		var found_in_game_dir := FileAccess.file_exists(mdl_path) \
-			and FileAccess.file_exists(vtx_path) \
-			and FileAccess.file_exists(vvd_path);
+		# Game directory paths
+		var mdl_path = VMFGameFolder.get_import_path(vpk_mdl_path);
+		var vtx_path = VMFGameFolder.get_import_path(vpk_vtx_path);
+		if not vtx_path:
+			vtx_path = VMFGameFolder.get_import_path(vpk_vtx_fallback_path);
+		var vvd_path = VMFGameFolder.get_import_path(vpk_vvd_path);
+		var phy_path = VMFGameFolder.get_import_path(vpk_phy_path);
+
+		var found_in_game_dir := mdl_path != "" and vtx_path != "" and vvd_path != "";
+
+		# Update vpk_vtx_path if fallback is used in VPK
+		if not file_exists_in_vpk(vpk_vtx_path) and file_exists_in_vpk(vpk_vtx_fallback_path):
+			vpk_vtx_path = vpk_vtx_fallback_path;
 
 		var found_in_vpk := file_exists_in_vpk(vpk_mdl_path) \
 			and file_exists_in_vpk(vpk_vtx_path) \
@@ -89,7 +90,7 @@ static func import_models(vmf_structure: VMFStructure) -> bool:
 			DirAccess.make_dir_recursive_absolute(target_path.get_base_dir());
 			DirAccess.copy_absolute(vtx_path, target_path + '.dx90.vtx');
 			DirAccess.copy_absolute(vvd_path, target_path + ".vvd");
-			if FileAccess.file_exists(phy_path): DirAccess.copy_absolute(phy_path, target_path + ".phy");
+			if phy_path != "": DirAccess.copy_absolute(phy_path, target_path + ".phy");
 			DirAccess.copy_absolute(mdl_path, target_path + ".mdl");
 
 		elif found_in_vpk:
@@ -123,23 +124,32 @@ static func file_exists_in_vpk(vpk_file_path: String) -> bool:
 	if not vpk_stack: return false;
 	return vpk_stack.exists(vpk_file_path);
 
+static func file_exists_in_additional_dir(file_path: String) -> bool:
+	if VMFConfig.import.additional_import_paths.size() == 0: return false;
+
+	for path in VMFConfig.import.additional_import_paths:
+		var full_path = VMFUtils.normalize_path(path + "/" + file_path);
+		if FileAccess.file_exists(full_path):
+			return true;
+
+	return false;
+
 static func import_material(material: String) -> bool:
 	material = material.to_lower();
 
 	var vpk_path = "materials/" + material + ".vmt";
-	var vmt_path = VMFUtils.normalize_path(VMFConfig.gameinfo_path + "/materials/" + material + ".vmt");
+	#var vmt_path = VMFUtils.normalize_path(VMFConfig.gameinfo_path + "/materials/" + material + ".vmt");
+	var vmt_path = VMFGameFolder.get_import_path(vpk_path); ## Returns the full path to the file if it exists in any of the game folder paths, otherwise returns an empty string
 	var target_path = VMFUtils.normalize_path(VMFConfig.materials.target_folder + "/" + material + ".vmt");
 
 	if ResourceLoader.exists(target_path): return false;
 
-	# Trying to find material in game directory first, as it can be overridden by mods and thus differ from the one in VPKs
-	if FileAccess.file_exists(vmt_path):
+	if vmt_path:
 		DirAccess.make_dir_recursive_absolute(target_path.get_base_dir());
 		if DirAccess.copy_absolute(vmt_path, target_path): return false;
 
 		has_imported_resources = true;
-
-	# Trying to find material in VPKs
+	# In case the file is not found in any of game folder paths - trying to find material in VPKs
 	elif file_exists_in_vpk(vpk_path):
 		if not vpk_stack.extract(vpk_path, target_path):
 			VMFLogger.error("Failed to extract material from VPK: " + vpk_path);
@@ -153,6 +163,7 @@ static func import_material(material: String) -> bool:
 
 	return has_imported_resources;
 
+## Looks through the VMF structure and imports all materials used in solids and entities, unless they are in the ignore list.
 static func import_materials(vmf_structure: VMFStructure, is_runtime := false) -> void:
 	var editor_interface = get_editor_interface();
 
@@ -192,12 +203,13 @@ static func import_materials(vmf_structure: VMFStructure, is_runtime := false) -
 static func import_textures(material: String) -> bool:
 	material = material.to_lower();
 
-	var target_path = VMFUtils.normalize_path(VMFConfig.gameinfo_path + "/materials/" + material + ".vmt");
+	## Returns the full path to the file if it exists in any of the game folder paths, otherwise returns an empty string
 	var vmt_vpk_path = "materials/" + material + ".vmt";
+	var target_path = VMFGameFolder.get_import_path(vmt_vpk_path); 
 
 	var details: Dictionary = {};
 
-	if FileAccess.file_exists(target_path): 
+	if target_path:  # If the material file exists in any of the game folder paths, parse it to get the details
 		details = VDFParser.parse(target_path, true).values()[0];
 
 	elif file_exists_in_vpk(vmt_vpk_path):
@@ -219,13 +231,14 @@ static func import_textures(material: String) -> bool:
 	for key in MATERIAL_KEYS_TO_IMPORT:
 		if key not in details: continue;
 		var vpk_path = VMFUtils.normalize_path("materials/" + details[key].to_lower() + ".vtf");
-		var vtf_path = VMFUtils.normalize_path(VMFConfig.gameinfo_path + "/materials/" + details[key].to_lower() + ".vtf");
+		## var vtf_path = VMFUtils.normalize_path(VMFConfig.gameinfo_path + "/materials/" + details[key].to_lower() + ".vtf");
+		var vtf_path = VMFGameFolder.get_import_path(vpk_path); ## Returns the full path to the file if it exists in any of the game folder paths, otherwise returns an empty string
 		var target_vtf_path = VMFUtils.normalize_path(VMFConfig.materials.target_folder + "/" + details[key].to_lower() + ".vtf");
 
 		if ResourceLoader.exists(target_vtf_path): continue;
 
 		# Trying to find texture in game directory first, as it can be overridden by mods and thus differ from the one in VPKs
-		if FileAccess.file_exists(vtf_path): 
+		if vtf_path: # If the texture file exists in any of the game folder paths, copy it to the target location
 			DirAccess.make_dir_recursive_absolute(target_vtf_path.get_base_dir());
 
 			if DirAccess.copy_absolute(vtf_path, target_vtf_path):


### PR DESCRIPTION
Adds support for multiple game info paths for resource import process
`Project Settings -> Godot VMF -> Import -> Additional Import Paths`