### PR TITLE
Include LICENSE into the release archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 /addons/** !export-ignore
 /script_templates    !export-ignore
 /script_templates/** !export-ignore
+LICENSE        !export-ignore


### PR DESCRIPTION
A new small requirement from Godot Asset Store to include LICENSE file into the release